### PR TITLE
[Feature] Project lead onboarding page

### DIFF
--- a/standards/project-leads/project-lead-onboarding.md
+++ b/standards/project-leads/project-lead-onboarding.md
@@ -1,0 +1,31 @@
+A project lead is an assigned point person whose primary concern is to provide project visibility to the engineering team. As a project lead, you have the following major responsibilities:
+
+## Project Updates and Reporting
+
+To keep the engineering team updated, you must provide weekly updates on the state of the project you’re assigned to. For this matter, the project leads team meets weekly to discuss project updates mostly but not limited to the following areas:
+
+- Deployments and releases  
+- Technical challenges faced  
+- Bugfixes and improvements  
+- Project demos and presentations
+
+In the event that you cannot attend the meeting (e.g. schedule conflict, on leave, etc) you should send project updates to the project leads team via message on slack.
+
+It will also be your responsibility to create and handle some periodic reports such as quarterly status reports and audits.
+
+## Highlights/Lowlights Monitoring
+
+As a project lead, it is also your responsibility to monitor the performance of the devs on your team. For this we do a weekly report called the highlights/lowlights report. Highlights can be defined as any successes or wins for the week while lowlights are any struggles or things to improve for the week. We have spreadsheets with instructions which we will provide for you. Take note that the highlights and lowlights are meant to help with the Career Performance Review (CPR) so fill them up with insights that will be useful for the ratings.
+
+## Skillsbase ratings
+
+As another means of quantifying developer performance and career pathing we use a platform called skills-base which contains a list of essential skills an MG developer should have and their corresponding ratings. It will also be your responsibility to monitor these skills and do a periodic update of the ratings (e.g. monthly).
+
+## Facilitate Dev Check-ins
+
+Dev check-ins are short (10-15 minute) weekly one-on-one sessions with each dev on the team. These meant to connect with the devs and can have a casual tone. It is meant to be brief and should cover at least the following:
+
+- How was the workload for this week?  
+- What are the challenges you faced?  
+- What went well? (Can discuss highlights)  
+- What can be improved? (Can discuss lowlights)


### PR DESCRIPTION
This PR adds a project lead onboarding guide, which was previously in a google doc, to the playbook. I also established a `/project-leads` folder which may be used for other project lead related items later.